### PR TITLE
Removed get prefixes for getters

### DIFF
--- a/src/Components/Component.php
+++ b/src/Components/Component.php
@@ -10,7 +10,7 @@ class Component extends Jsonable
         protected int $type
     ) { }
 
-    public function getType(): int
+    public function type(): int
     {
         return $this->type;
     }
@@ -18,7 +18,7 @@ class Component extends Jsonable
     public function jsonSerialize(): array
     {
         return [
-            'type' => $this->getType(),
+            'type' => $this->type(),
         ];
     }
 }

--- a/src/Components/Types/ActionRow.php
+++ b/src/Components/Types/ActionRow.php
@@ -24,7 +24,7 @@ class ActionRow extends Component
     /**
      * @return Component[]
      */
-    public function getComponents(): array
+    public function components(): array
     {
         return $this->components;
     }

--- a/src/Components/Types/SelectMenu.php
+++ b/src/Components/Types/SelectMenu.php
@@ -27,12 +27,12 @@ class SelectMenu extends Component
         $this->maxValues = $maxValues;
     }
 
-    public function getId(): string
+    public function id(): string
     {
         return $this->id;
     }
 
-    public function getPlaceholder(): ?string
+    public function placeholder(): ?string
     {
         return $this->placeholder;
     }
@@ -42,7 +42,7 @@ class SelectMenu extends Component
         $this->placeholder = $placeholder;
     }
 
-    public function getMinValues(): ?int
+    public function minValues(): ?int
     {
         return $this->minValues;
     }
@@ -52,7 +52,7 @@ class SelectMenu extends Component
         $this->minValues = $minValues;
     }
 
-    public function getMaxValues(): ?int
+    public function maxValues(): ?int
     {
         return $this->maxValues;
     }
@@ -80,10 +80,10 @@ class SelectMenu extends Component
     public function jsonSerialize(): array
     {
         $data = [
-            'custom_id' => $this->getId(),
-            'placeholder' => $this->getPlaceholder(),
-            'min_values' => $this->getMinValues(),
-            'max_values' => $this->getMaxValues(),
+            'custom_id' => $this->id(),
+            'placeholder' => $this->placeholder(),
+            'min_values' => $this->minValues(),
+            'max_values' => $this->maxValues(),
             'disabled' => $this->isDisabled(),
         ];
 

--- a/src/Components/Types/SelectMenu/ChannelSelectMenu.php
+++ b/src/Components/Types/SelectMenu/ChannelSelectMenu.php
@@ -26,7 +26,7 @@ class ChannelSelectMenu extends SelectMenu
         return count($this->channelTypes) > 0;
     }
 
-    public function getChannelTypes(): array
+    public function channelTypes(): array
     {
         return $this->channelTypes;
     }

--- a/src/Components/Types/SelectMenu/Option.php
+++ b/src/Components/Types/SelectMenu/Option.php
@@ -22,22 +22,22 @@ class Option
         $this->default = $default;
     }
 
-    public function setLabel(string $label)
+    public function setLabel(string $label): void
     {
         $this->label = $label;
     }
 
-    public function getLabel(): string
+    public function label(): string
     {
         return $this->label;
     }
 
-    public function setValue(string $value)
+    public function setValue(string $value): void
     {
         $this->value = $value;
     }
 
-    public function getValue(): string
+    public function value(): string
     {
         return $this->value;
     }
@@ -47,7 +47,7 @@ class Option
         $this->description = $description;
     }
 
-    public function getDescription(): string
+    public function description(): string
     {
         return $this->description;
     }
@@ -70,13 +70,13 @@ class Option
     public function jsonSerialize(): array
     {
         $data = [
-            'label' => $this->getLabel(),
-            'value' => $this->getValue(),
+            'label' => $this->label(),
+            'value' => $this->value(),
             'default' => $this->isDefault(),
         ];
 
         if ($this->hasDescription()) {
-            $data['description'] = $this->getDescription();
+            $data['description'] = $this->description();
         }
 
         if ($this->emoji instanceof PartialEmoji) {

--- a/src/Components/Types/SelectMenu/StringSelectMenu.php
+++ b/src/Components/Types/SelectMenu/StringSelectMenu.php
@@ -29,12 +29,12 @@ class StringSelectMenu extends SelectMenu
     {
         foreach ($this->options as $option) {
             $option->setDefault(
-                $optionLabel === $option->getLabel()
+                $optionLabel === $option->label()
             );
         }
     }
 
-    public function getOptions(): array
+    public function options(): array
     {
         return $this->options;
     }

--- a/src/Components/Types/TextInput.php
+++ b/src/Components/Types/TextInput.php
@@ -35,12 +35,12 @@ class TextInput extends Component
         $this->placeholder = $placeholder;
     }
 
-    public function getId(): string
+    public function id(): string
     {
         return $this->id;
     }
 
-    public function getStyle(): int
+    public function style(): int
     {
         return $this->style;
     }

--- a/src/Message.php
+++ b/src/Message.php
@@ -52,7 +52,7 @@ class Message extends Jsonable implements Hydrateable
         return preg_match('#<@&.+?>#', $this->content());
     }
 
-    public function getMentionedRoleIds(): ?array
+    public function mentionedRoleIds(): ?array
     {
         preg_match_all('#<@&(.+?)>#', $this->content(), $matches);
 

--- a/src/WebhookMessage.php
+++ b/src/WebhookMessage.php
@@ -58,7 +58,7 @@ class WebhookMessage extends Jsonable implements Hydrateable
         return preg_match('#<@&.+?>#', $this->content());
     }
 
-    public function getMentionedRoleIds(): array
+    public function mentionedRoleIds(): array
     {
         preg_match_all('#<@&(.+?)>#', $this->content(), $matches);
 

--- a/tests/Components/Types/ActionRowTest.php
+++ b/tests/Components/Types/ActionRowTest.php
@@ -19,22 +19,22 @@ class ActionRowTest extends TestCase
     /** @test */
     public function canAddAndProvideComponents()
     {
-        $this->assertCount(0, $this->actionRow->getComponents());
+        $this->assertCount(0, $this->actionRow->components());
 
         $component = \Mockery::mock(Component::class);
         $this->actionRow->addComponent($component);
-        $this->assertCount(1, $this->actionRow->getComponents());
-        $this->assertEquals($component, $this->actionRow->getComponents()[0]);
+        $this->assertCount(1, $this->actionRow->components());
+        $this->assertEquals($component, $this->actionRow->components()[0]);
 
         $componentB = new class(time()) extends Component {
 
         };
         $this->actionRow->setComponents([$componentB]);
-        $this->assertCount(1, $this->actionRow->getComponents());
-        $this->assertEquals($componentB, $this->actionRow->getComponents()[0]);
+        $this->assertCount(1, $this->actionRow->components());
+        $this->assertEquals($componentB, $this->actionRow->components()[0]);
 
         $json = $this->actionRow->jsonSerialize();
         $this->assertArrayHasKey('components', $json);
-        $this->assertEquals($componentB->getType(), $json['components'][0]['type']);
+        $this->assertEquals($componentB->type(), $json['components'][0]['type']);
     }
 }

--- a/tests/Components/Types/SelectMenu/ChannelSelectMenuTest.php
+++ b/tests/Components/Types/SelectMenu/ChannelSelectMenuTest.php
@@ -18,13 +18,13 @@ class ChannelSelectMenuTest extends TestCase
             ],
         );
 
-        $this->assertEquals($id, $selectMenu->getId());
-        $this->assertEquals(Channel::TYPE_GUILD_TEXT, $selectMenu->getChannelTypes()[0]);
+        $this->assertEquals($id, $selectMenu->id());
+        $this->assertEquals(Channel::TYPE_GUILD_TEXT, $selectMenu->channelTypes()[0]);
 
         $json = $selectMenu->jsonSerialize();
 
         $this->assertArrayHasKey('custom_id', $json);
-        $this->assertEquals($selectMenu->getId(), $json['custom_id']);
+        $this->assertEquals($selectMenu->id(), $json['custom_id']);
 
         $this->assertArrayHasKey('channel_types', $json);
         $this->assertTrue(in_array(Channel::TYPE_GUILD_TEXT, $json['channel_types']));
@@ -38,12 +38,12 @@ class ChannelSelectMenuTest extends TestCase
             id: $id,
         );
 
-        $this->assertEquals($id, $selectMenu->getId());
+        $this->assertEquals($id, $selectMenu->id());
 
         $json = $selectMenu->jsonSerialize();
 
         $this->assertArrayHasKey('custom_id', $json);
-        $this->assertEquals($selectMenu->getId(), $json['custom_id']);
+        $this->assertEquals($selectMenu->id(), $json['custom_id']);
 
         $this->assertArrayNotHasKey('channel_types', $json);
     }

--- a/tests/Components/Types/SelectMenu/OptionTest.php
+++ b/tests/Components/Types/SelectMenu/OptionTest.php
@@ -14,15 +14,15 @@ class OptionTest extends TestCase
         $value = 'some-value';
         $option = new Option($label, $value);
 
-        $this->assertEquals($label, $option->getLabel());
-        $this->assertEquals($value, $option->getValue());
+        $this->assertEquals($label, $option->label());
+        $this->assertEquals($value, $option->value());
 
         $json = $option->jsonSerialize();
 
         $this->assertArrayHasKey('label', $json);
-        $this->assertEquals($option->getLabel(), $json['label']);
+        $this->assertEquals($option->label(), $json['label']);
 
         $this->assertArrayHasKey('value', $json);
-        $this->assertEquals($option->getValue(), $json['value']);
+        $this->assertEquals($option->value(), $json['value']);
     }
 }

--- a/tests/Components/Types/SelectMenu/StringSelectMenuTest.php
+++ b/tests/Components/Types/SelectMenu/StringSelectMenuTest.php
@@ -18,17 +18,17 @@ class StringSelectMenuTest extends TestCase
             options: [$option1]
         );
 
-        $this->assertEquals($id, $selectMenu->getId());
-        $this->assertEquals($option1, $selectMenu->getOptions()[0]);
+        $this->assertEquals($id, $selectMenu->id());
+        $this->assertEquals($option1, $selectMenu->options()[0]);
 
         $json = $selectMenu->jsonSerialize();
 
         $this->assertArrayHasKey('custom_id', $json);
-        $this->assertEquals($selectMenu->getId(), $json['custom_id']);
+        $this->assertEquals($selectMenu->id(), $json['custom_id']);
 
         $this->assertArrayHasKey('options', $json);
-        $this->assertEquals($option1->getLabel(), $json['options'][0]['label']);
-        $this->assertEquals($option1->getValue(), $json['options'][0]['value']);
+        $this->assertEquals($option1->label(), $json['options'][0]['label']);
+        $this->assertEquals($option1->value(), $json['options'][0]['value']);
     }
 
     /** @test */
@@ -42,10 +42,10 @@ class StringSelectMenuTest extends TestCase
             options: [$option1],
         );
 
-        $this->assertFalse($selectMenu->getOptions()[0]->isDefault());
+        $this->assertFalse($selectMenu->options()[0]->isDefault());
 
-        $selectMenu->makeDefault($option1->getLabel());
+        $selectMenu->makeDefault($option1->label());
 
-        $this->assertTrue($selectMenu->getOptions()[0]->isDefault());
+        $this->assertTrue($selectMenu->options()[0]->isDefault());
     }
 }

--- a/tests/Components/Types/SelectMenuTest.php
+++ b/tests/Components/Types/SelectMenuTest.php
@@ -12,11 +12,11 @@ class SelectMenuTest extends TestCase
         $id = 'asdf';
         $selectMenu = new SelectMenu(1, $id);
 
-        $this->assertEquals($id, $selectMenu->getId());
+        $this->assertEquals($id, $selectMenu->id());
 
         $json = $selectMenu->jsonSerialize();
 
         $this->assertArrayHasKey('custom_id', $json);
-        $this->assertEquals($selectMenu->getId(), $json['custom_id']);
+        $this->assertEquals($selectMenu->id(), $json['custom_id']);
     }
 }

--- a/tests/Components/Types/TextInput/ParagraphInputTest.php
+++ b/tests/Components/Types/TextInput/ParagraphInputTest.php
@@ -14,7 +14,7 @@ class ParagraphInputTest extends TestCase
         $label = 'my-field';
         $input = new ParagraphInput($id, $label);
 
-        $this->assertEquals(2, $input->getStyle());
+        $this->assertEquals(2, $input->style());
         $this->assertEquals($label, $input->label());
 
         $json = $input->jsonSerialize();

--- a/tests/Components/Types/TextInput/ShortInputTest.php
+++ b/tests/Components/Types/TextInput/ShortInputTest.php
@@ -14,7 +14,7 @@ class ShortInputTest extends TestCase
         $label = 'my-field';
         $input = new ShortInput($id, $label);
 
-        $this->assertEquals(1, $input->getStyle());
+        $this->assertEquals(1, $input->style());
         $this->assertEquals($label, $input->label());
 
         $json = $input->jsonSerialize();

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -39,7 +39,7 @@ class MessageTest extends TestCase
         $this->assertEquals([
             $firstRoleId,
             $secondRoleId,
-        ], $this->message->getMentionedRoleIds());
+        ], $this->message->mentionedRoleIds());
     }
 
     /** @test */

--- a/tests/WebhookMessageTest.php
+++ b/tests/WebhookMessageTest.php
@@ -41,7 +41,7 @@ class WebhookMessageTest extends TestCase
         $this->assertEquals([
             $firstRoleId,
             $secondRoleId,
-        ], $this->message->getMentionedRoleIds());
+        ], $this->message->mentionedRoleIds());
     }
 
     /** @test */


### PR DESCRIPTION
Recent work on the original `more-cores/discord-message-builder` package resulted in some inconsistencies with getter method naming.  This PR brings us back in line with the `get` prefix being excluded from such methods.