### PR TITLE
Add actionRow() shorthand and abstract classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,14 @@ $embed->setFooter($thumbnail);
 
 ### Buttons
 
+Use dedicated classes for each button type.  Because buttons are non-interactive, you'll need to wrap them with an `ActionRow` when adding them to a message.  You can use the shorthand `actionRow()` to accomplish this.
+
 ```php
-$message->addComponent(new SuccessButton('button-id', 'Approve it'));
-$message->addComponent(new DangerButton('button-id', 'Reject it'));
-$message->addComponent(new PrimaryButton('button-id', 'Something else'));
-$message->addComponent(new SecondaryButton('button-id', 'Something else'));
-$message->addComponent(new LinkButton('https://mysite.com', 'My Site'));
+$message->actionRow(new SuccessButton('button-id', 'Approve it'));
+$message->actionRow(new DangerButton('button-id', 'Reject it'));
+$message->actionRow(new PrimaryButton('button-id', 'Something else'));
+$message->actionRow(new SecondaryButton('button-id', 'Something else'));
+$message->actionRow(new LinkButton('https://mysite.com', 'My Site'));
 ```
 
 ### SelectMenus

--- a/src/Messages/Components/Types/Button.php
+++ b/src/Messages/Components/Types/Button.php
@@ -5,7 +5,7 @@ namespace DiscordBuilder\Messages\Components\Types;
 use DiscordBuilder\Messages\Components\Component;
 use DiscordBuilder\PartialEmoji;
 
-class Button extends Component
+abstract class Button extends Component
 {
     public const TYPE = 2;
 

--- a/src/Messages/Components/Types/SelectMenu.php
+++ b/src/Messages/Components/Types/SelectMenu.php
@@ -4,7 +4,7 @@ namespace DiscordBuilder\Messages\Components\Types;
 
 use DiscordBuilder\Messages\Components\Component;
 
-class SelectMenu extends Component
+abstract class SelectMenu extends Component
 {
     protected ?string $placeholder;
     protected ?int $minValues;

--- a/src/Messages/Components/Types/TextInput.php
+++ b/src/Messages/Components/Types/TextInput.php
@@ -4,7 +4,7 @@ namespace DiscordBuilder\Messages\Components\Types;
 
 use DiscordBuilder\Messages\Components\Component;
 
-class TextInput extends Component
+abstract class TextInput extends Component
 {
     public const TYPE = 4;
 

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -6,6 +6,8 @@ use DiscordBuilder\Hydrateable;
 use DiscordBuilder\Jsonable;
 use DiscordBuilder\Messages\Components\Component;
 use DiscordBuilder\Messages\Components\HasComponents;
+use DiscordBuilder\Messages\Components\Types\ActionRow;
+use DiscordBuilder\Messages\Components\Types\Button;
 use DiscordBuilder\Messages\Embed\Embed;
 
 class Message extends Jsonable implements Hydrateable
@@ -80,6 +82,10 @@ class Message extends Jsonable implements Hydrateable
         return str_contains($this->content, '<@&' . $roleId . '>');
     }
 
+    public function actionRow(Button ... $components)
+    {
+        $this->addComponent(new ActionRow(func_get_args()));
+    }
 
     public function hydrate(array $array): self
     {

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -82,7 +82,7 @@ class Message extends Jsonable implements Hydrateable
         return str_contains($this->content, '<@&' . $roleId . '>');
     }
 
-    public function actionRow(Button ... $components)
+    public function actionRow(Button ... $buttons)
     {
         $this->addComponent(new ActionRow(func_get_args()));
     }

--- a/tests/Messages/Components/Types/SelectMenuTest.php
+++ b/tests/Messages/Components/Types/SelectMenuTest.php
@@ -10,7 +10,9 @@ class SelectMenuTest extends TestCase
     public function canBeConstructedAndJsonified()
     {
         $id = 'asdf';
-        $selectMenu = new SelectMenu(1, $id);
+        $selectMenu = new class(1, $id) extends SelectMenu {
+
+        };
 
         $this->assertEquals($id, $selectMenu->id());
 

--- a/tests/Messages/MessageTest.php
+++ b/tests/Messages/MessageTest.php
@@ -2,6 +2,7 @@
 
 namespace DiscordBuilder\Messages;
 
+use DiscordBuilder\Messages\Components\Types\ActionRow;
 use DiscordBuilder\Messages\Components\Types\Buttons\PrimaryButton;
 use DiscordBuilder\Messages\Embed\Embed;
 use PHPUnit\Framework\TestCase;
@@ -101,5 +102,24 @@ class MessageTest extends TestCase
         $json = $this->message->jsonSerialize();
         $this->assertArrayHasKey('components', $json);
         $this->assertEquals($compId, $json['components'][0]['custom_id']);
+    }
+
+    /** @test */
+    public function canAddComponentsAsActionRow()
+    {
+        $this->assertFalse($this->message->hasComponents());
+
+        $compId = '3j34jsdfl';
+        $component = new PrimaryButton($compId);
+        $this->message->actionRow($component);
+        $this->assertTrue($this->message->hasComponents());
+
+        $components = $this->message->components();
+        $this->assertInstanceOf(ActionRow::class, $components[0]);
+
+        $json = $this->message->jsonSerialize();
+
+        $this->assertArrayHasKey('components', $json);
+        $this->assertEquals($component->type(), $json['components'][0]['components'][0]['type']);
     }
 }


### PR DESCRIPTION
 - Base Component classes not intended to be used together are now `abstract` to help avoid confusion.  
 - `$message->actionRow()` shorthand method has been added for adding buttons to a message