### PR TITLE
Add support for component interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,3 +401,42 @@ public function whenSubmitted(
 ```
 
 The key takeaway here is that Discord _requires_ an interaction in response to the modal submission.  So you'll need to respond with something.
+
+### Component Interactions
+
+When a user clicks a button or makes a selection in a select menu, Discord sends a `ComponentInteracted` interaction.  You can identify which component was used via its `custom_id`, and read any selected values.
+
+```php
+if ($interaction instanceof ComponentInteracted) {
+    $interaction->customId();    // the custom_id of the button/menu that was used
+    $interaction->isButton();    // true for buttons
+    $interaction->isSelectMenu();// true for any select menu
+    $interaction->values();      // the selected values (empty for buttons)
+    $interaction->message();     // the original message the component is attached to
+
+    // respond with one of the responses below
+}
+```
+
+#### Updating the original message
+
+Instead of sending a new message, you can edit the message the component is attached to (for example, to disable a button after it's clicked) by responding with an `UpdateMessage`:
+
+```php
+return new UpdateMessage(
+    content: 'Thanks, recorded your vote!',
+    components: [], // pass an empty array to remove the components
+);
+```
+
+#### Deferring a response
+
+Discord requires a response within 3 seconds.  If you need longer, acknowledge the interaction first and follow up later:
+
+```php
+// for a command interaction - shows a loading state, then you edit the reply later
+return new DeferReply(onlyVisibleToCommandIssuer: true);
+
+// for a component interaction - acknowledges without showing anything, then you edit the message later
+return new DeferUpdate();
+```

--- a/src/Commands/Interactions/InteractionTypeFactory.php
+++ b/src/Commands/Interactions/InteractionTypeFactory.php
@@ -4,6 +4,7 @@ namespace DiscordCommands\Commands\Interactions;
 
 use DiscordCommands\Commands\Interactions\Types\ChatCommandExecuted;
 use DiscordCommands\Commands\Interactions\Types\ChatCommandExecutionWantsAutocompletionOptions;
+use DiscordCommands\Commands\Interactions\Types\ComponentInteracted;
 use DiscordCommands\Commands\Interactions\Types\ModalSubmitted;
 use DiscordCommands\Commands\Interactions\Types\Ping;
 
@@ -14,6 +15,7 @@ class InteractionTypeFactory
         $interaction = match ($type) {
             Ping::TYPE                                              => new Ping(),
             ChatCommandExecuted::TYPE                               => new ChatCommandExecuted(),
+            ComponentInteracted::TYPE                               => new ComponentInteracted(),
             ChatCommandExecutionWantsAutocompletionOptions::TYPE    => new ChatCommandExecutionWantsAutocompletionOptions(),
             ModalSubmitted::TYPE                                    => new ModalSubmitted(),
         };

--- a/src/Commands/Interactions/Responding/DeferReply.php
+++ b/src/Commands/Interactions/Responding/DeferReply.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace DiscordCommands\Commands\Interactions\Responding;
+
+use DiscordCommands\Jsonable;
+
+/**
+ * Acknowledges a command interaction and shows a loading state to the user,
+ * allowing you to send the actual reply later (within 15 minutes).  Useful when
+ * the work needed to respond can't finish within Discord's 3 second window.
+ */
+class DeferReply extends Jsonable implements CommandResponse
+{
+    public const TYPE = 5;
+
+    public const FLAG_EPHEMERAL = 0x0000000000000040;
+
+    protected array $flags = [];
+
+    public function __construct(
+        ?bool $onlyVisibleToCommandIssuer = null,
+    ) {
+        if ($onlyVisibleToCommandIssuer !== null) {
+            $this->onlyVisibleToCommandIssuer();
+        }
+    }
+
+    public function onlyVisibleToCommandIssuer(): void
+    {
+        $this->flags[] = self::FLAG_EPHEMERAL;
+    }
+
+    public function jsonSerialize(): array
+    {
+        $response = [
+            'type' => self::TYPE,
+        ];
+
+        if (count($this->flags) > 0) {
+            $response['data'] = [
+                'flags' => array_sum($this->flags),
+            ];
+        }
+
+        return $response;
+    }
+}

--- a/src/Commands/Interactions/Responding/DeferUpdate.php
+++ b/src/Commands/Interactions/Responding/DeferUpdate.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace DiscordCommands\Commands\Interactions\Responding;
+
+use DiscordCommands\Jsonable;
+
+/**
+ * Acknowledges a component interaction without immediately editing the message.
+ * The message can be edited later.  Nothing is shown to the user in the
+ * meantime.
+ */
+class DeferUpdate extends Jsonable implements CommandResponse
+{
+    public const TYPE = 6;
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'type' => self::TYPE,
+        ];
+    }
+}

--- a/src/Commands/Interactions/Responding/UpdateMessage.php
+++ b/src/Commands/Interactions/Responding/UpdateMessage.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace DiscordCommands\Commands\Interactions\Responding;
+
+use DiscordCommands\Jsonable;
+use DiscordCommands\Messages\Components\Component;
+use DiscordCommands\Messages\Components\HasComponents;
+use DiscordCommands\Messages\Embed\Embed;
+use DiscordCommands\Messages\HasEmbeds;
+
+/**
+ * Responds to a component interaction by editing the message the component is
+ * attached to, rather than sending a new message.
+ */
+class UpdateMessage extends Jsonable implements CommandResponse
+{
+    public const TYPE = 7;
+
+    public const FLAG_SUPPRESS_EMBEDS = 0x0000000000000004;
+
+    use HasComponents;
+    use HasEmbeds;
+
+    protected ?string $content;
+    protected array $embeds = [];
+    protected array $flags = [];
+
+    /**
+     * @param string|null $content
+     * @param Embed[]|null $embeds
+     * @param Component[]|null $components
+     */
+    public function __construct(
+        ?string $content = null,
+        array $embeds = [],
+        array $components = [],
+        ?bool $withoutExpandingEmbeds = null,
+    ) {
+        $this->content = $content;
+        $this->embeds = $embeds;
+        $this->components = $components;
+
+        if ($withoutExpandingEmbeds !== null) {
+            $this->withoutExpandingEmbeds();
+        }
+    }
+
+    public function setContent(string $content): void
+    {
+        $this->content = $content;
+    }
+
+    public function content(): string
+    {
+        return (string) $this->content;
+    }
+
+    public function hasContent(): bool
+    {
+        return $this->content != null;
+    }
+
+    public function withoutExpandingEmbeds(): void
+    {
+        $this->flags[] = self::FLAG_SUPPRESS_EMBEDS;
+    }
+
+    public function jsonSerialize(): array
+    {
+        $jsonData = [
+            'content' => $this->content(),
+        ];
+
+        if (count($this->flags) > 0) {
+            $jsonData['flags'] = array_sum($this->flags);
+        }
+
+        $traitsUsed = array_merge(class_uses(self::class), class_uses($this));
+        if (in_array(HasComponents::class, $traitsUsed)) {
+            $jsonData['components'] = $this->serializeComponents();
+        }
+        if (in_array(HasEmbeds::class, $traitsUsed)) {
+            $jsonData['embeds'] = $this->serializeEmbeds();
+        }
+
+        return [
+            'type' => self::TYPE,
+            'data' => $jsonData,
+        ];
+    }
+}

--- a/src/Commands/Interactions/Types/ComponentInteracted.php
+++ b/src/Commands/Interactions/Types/ComponentInteracted.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace DiscordCommands\Commands\Interactions\Types;
+
+use DiscordCommands\Commands\Interactions\Interaction;
+
+/**
+ * Sent by Discord when a user interacts with a message component, such as
+ * clicking a button or making a selection in a select menu.
+ */
+class ComponentInteracted extends Interaction
+{
+    public const TYPE = 3;
+
+    protected ?string $customId = null;
+    protected ?int $componentType = null;
+    protected array $values = [];
+    protected ?array $message = null;
+
+    public function __construct()
+    {
+        parent::__construct(
+            type: self::TYPE,
+        );
+    }
+
+    /**
+     * The custom_id of the component that was interacted with.
+     */
+    public function customId(): string
+    {
+        return (string) $this->customId;
+    }
+
+    public function hasCustomId(): bool
+    {
+        return $this->customId !== null;
+    }
+
+    /**
+     * The type of the component that was interacted with (e.g. 2 for a button,
+     * 3 for a string select menu).
+     */
+    public function componentType(): ?int
+    {
+        return $this->componentType;
+    }
+
+    public function isButton(): bool
+    {
+        return $this->componentType === 2;
+    }
+
+    public function isSelectMenu(): bool
+    {
+        return in_array($this->componentType, [3, 5, 6, 7, 8], true);
+    }
+
+    /**
+     * The values selected in a select menu.  Empty for buttons.
+     *
+     * @return string[]
+     */
+    public function values(): array
+    {
+        return $this->values;
+    }
+
+    public function hasValues(): bool
+    {
+        return count($this->values) > 0;
+    }
+
+    /**
+     * The message the interacted component is attached to.  Useful when
+     * responding with an UpdateMessage to edit it in place.
+     */
+    public function message(): ?array
+    {
+        return $this->message;
+    }
+
+    public function hasMessage(): bool
+    {
+        return $this->message !== null;
+    }
+
+    public function hydrate(array $array): self
+    {
+        if (isset($array['data']['custom_id'])) {
+            $this->customId = $array['data']['custom_id'];
+        }
+
+        if (isset($array['data']['component_type'])) {
+            $this->componentType = $array['data']['component_type'];
+        }
+
+        if (isset($array['data']['values'])) {
+            $this->values = $array['data']['values'];
+        }
+
+        if (isset($array['message'])) {
+            $this->message = $array['message'];
+        }
+
+        return parent::hydrate($array);
+    }
+}

--- a/tests/Commands/Interactions/InteractionFactoryTest.php
+++ b/tests/Commands/Interactions/InteractionFactoryTest.php
@@ -4,6 +4,8 @@ namespace DiscordCommands\Commands\Interactions;
 
 use DiscordCommands\Commands\Interactions\Types\ChatCommandExecuted;
 use DiscordCommands\Commands\Interactions\Types\ChatCommandExecutionWantsAutocompletionOptions;
+use DiscordCommands\Commands\Interactions\Types\ComponentInteracted;
+use DiscordCommands\Commands\Interactions\Types\ModalSubmitted;
 use DiscordCommands\Commands\Interactions\Types\Ping;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -28,6 +30,16 @@ class InteractionFactoryTest extends TestCase
         $this->assertInstanceOf(
             ChatCommandExecutionWantsAutocompletionOptions::class,
             $factory->make(ChatCommandExecutionWantsAutocompletionOptions::TYPE, [])
+        );
+
+        $this->assertInstanceOf(
+            ComponentInteracted::class,
+            $factory->make(ComponentInteracted::TYPE, [])
+        );
+
+        $this->assertInstanceOf(
+            ModalSubmitted::class,
+            $factory->make(ModalSubmitted::TYPE, [])
         );
     }
 }

--- a/tests/Commands/Interactions/Responding/DeferReplyTest.php
+++ b/tests/Commands/Interactions/Responding/DeferReplyTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace DiscordCommands\Commands\Interactions\Responding\Responses;
+
+use DiscordCommands\Commands\Interactions\Responding\DeferReply;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class DeferReplyTest extends TestCase
+{
+    #[Test]
+    public function serializes()
+    {
+        $json = (new DeferReply())->jsonSerialize();
+
+        $this->assertEquals(DeferReply::TYPE, $json['type']);
+        $this->assertEquals(5, $json['type']);
+        $this->assertArrayNotHasKey('data', $json);
+    }
+
+    #[Test]
+    public function canBeEphemeral()
+    {
+        $json = (new DeferReply(onlyVisibleToCommandIssuer: true))->jsonSerialize();
+
+        $this->assertArrayHasKey('flags', $json['data']);
+
+        if (!(DeferReply::FLAG_EPHEMERAL & $json['data']['flags'])) {
+            $this->assertTrue(false, 'ephemeral bitwise operator not applied');
+        }
+    }
+}

--- a/tests/Commands/Interactions/Responding/DeferUpdateTest.php
+++ b/tests/Commands/Interactions/Responding/DeferUpdateTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace DiscordCommands\Commands\Interactions\Responding\Responses;
+
+use DiscordCommands\Commands\Interactions\Responding\DeferUpdate;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class DeferUpdateTest extends TestCase
+{
+    #[Test]
+    public function serializes()
+    {
+        $json = (new DeferUpdate())->jsonSerialize();
+
+        $this->assertEquals(DeferUpdate::TYPE, $json['type']);
+        $this->assertEquals(6, $json['type']);
+    }
+}

--- a/tests/Commands/Interactions/Responding/UpdateMessageTest.php
+++ b/tests/Commands/Interactions/Responding/UpdateMessageTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace DiscordCommands\Commands\Interactions\Responding\Responses;
+
+use DiscordCommands\Commands\Interactions\Responding\UpdateMessage;
+use DiscordCommands\Messages\Components\Types\Buttons\PrimaryButton;
+use DiscordCommands\Messages\Embed\Embed;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class UpdateMessageTest extends TestCase
+{
+    #[Test]
+    public function serializes()
+    {
+        $response = new UpdateMessage(
+            content: $content = 'something-here',
+        );
+
+        $this->assertEquals($content, $response->content());
+
+        $json = $response->jsonSerialize();
+
+        $this->assertEquals(UpdateMessage::TYPE, $json['type']);
+        $this->assertEquals(7, $json['type']);
+        $this->assertEquals($content, $json['data']['content']);
+    }
+
+    #[Test]
+    public function serializesFlags()
+    {
+        $response = new UpdateMessage();
+
+        $response->withoutExpandingEmbeds();
+
+        $json = $response->jsonSerialize();
+
+        $this->assertArrayHasKey('flags', $json['data']);
+
+        if (!(UpdateMessage::FLAG_SUPPRESS_EMBEDS & $json['data']['flags'])) {
+            $this->assertTrue(false, 'suppress embeds bitwise operator not applied');
+        }
+    }
+
+    #[Test]
+    public function verifyUsesComponents()
+    {
+        $response = new UpdateMessage();
+
+        $this->assertFalse($response->hasComponents());
+
+        $compId = '34';
+        $response->addComponent(new PrimaryButton($compId));
+
+        $this->assertTrue($response->hasComponents());
+
+        $json = $response->jsonSerialize();
+
+        $this->assertArrayHasKey('components', $json['data']);
+        $this->assertEquals($compId, $json['data']['components'][0]['custom_id']);
+    }
+
+    #[Test]
+    public function verifyUsesEmbeds()
+    {
+        $response = new UpdateMessage();
+
+        $this->assertFalse($response->hasEmbeds());
+
+        $title = 'something';
+        $response->addEmbed(new Embed(title: $title));
+
+        $this->assertTrue($response->hasEmbeds());
+
+        $json = $response->jsonSerialize();
+
+        $this->assertArrayHasKey('embeds', $json['data']);
+        $this->assertEquals($title, $json['data']['embeds'][0]['title']);
+    }
+}

--- a/tests/Commands/Interactions/Types/ComponentInteractedTest.php
+++ b/tests/Commands/Interactions/Types/ComponentInteractedTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace DiscordCommands\Commands\Interactions\Types;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class ComponentInteractedTest extends TestCase
+{
+    #[Test]
+    public function hydratesSharedInteractionFields()
+    {
+        $interaction = new ComponentInteracted();
+
+        $this->assertFalse($interaction->hasId());
+        $this->assertFalse($interaction->hasGuildId());
+
+        // Verify fields can be missing when hydrating
+        $interaction->hydrate([]);
+
+        $interaction->hydrate([
+            'id' => $id = 2038585834,
+            'application_id' => $appId = 12,
+            'guild_id' => $guildId = '1223',
+            'channel_id' => $channelId = '134988',
+        ]);
+
+        $this->assertEquals($id, $interaction->id());
+        $this->assertEquals($appId, $interaction->applicationId());
+        $this->assertEquals($guildId, $interaction->guildId());
+        $this->assertEquals($channelId, $interaction->channelId());
+    }
+
+    #[Test]
+    public function hydratesAButtonClick()
+    {
+        $interaction = new ComponentInteracted();
+
+        $this->assertFalse($interaction->hasCustomId());
+        $this->assertFalse($interaction->hasValues());
+
+        $interaction->hydrate([
+            'data' => [
+                'custom_id' => $customId = 'approve-button',
+                'component_type' => 2,
+            ],
+            'message' => $message = ['id' => '998877', 'content' => 'original'],
+        ]);
+
+        $this->assertTrue($interaction->hasCustomId());
+        $this->assertEquals($customId, $interaction->customId());
+        $this->assertEquals(2, $interaction->componentType());
+        $this->assertTrue($interaction->isButton());
+        $this->assertFalse($interaction->isSelectMenu());
+        $this->assertFalse($interaction->hasValues());
+        $this->assertEquals([], $interaction->values());
+
+        $this->assertTrue($interaction->hasMessage());
+        $this->assertEquals($message, $interaction->message());
+    }
+
+    #[Test]
+    public function hydratesASelectMenuSelection()
+    {
+        $interaction = new ComponentInteracted();
+
+        $interaction->hydrate([
+            'data' => [
+                'custom_id' => $customId = 'pick-one',
+                'component_type' => 3,
+                'values' => $values = ['option-1', 'option-3'],
+            ],
+        ]);
+
+        $this->assertEquals($customId, $interaction->customId());
+        $this->assertEquals(3, $interaction->componentType());
+        $this->assertFalse($interaction->isButton());
+        $this->assertTrue($interaction->isSelectMenu());
+        $this->assertTrue($interaction->hasValues());
+        $this->assertEquals($values, $interaction->values());
+    }
+}


### PR DESCRIPTION
## What

The library can already *build* buttons and select menus, but it had no way to *handle* a user actually using them. Discord delivers those as interaction **type 3 (MESSAGE_COMPONENT)**, which had no handler — only Ping (1), ChatCommand (2), Autocomplete (4), and ModalSubmit (5) existed. This closes that loop.

## Changes

- **`ComponentInteracted`** (inbound type 3) — mirrors `ModalSubmitted`. Exposes `customId()`, `componentType()`, `isButton()`/`isSelectMenu()`, `values()` (selected select-menu values), and `message()` (the original message the component is attached to). Registered in `InteractionTypeFactory`.
- **`UpdateMessage`** (response type 7) — edit the message a component lives on (e.g. disable a button after a click) instead of posting a new reply.
- **`DeferReply`** (type 5) / **`DeferUpdate`** (type 6) — acknowledge an interaction within Discord's 3-second window and follow up later.

## Tests

10 new tests (118 total, all green). Covers button vs. select-menu hydration, the new factory arm, and serialization of each response type.

## Docs

Added a "Component Interactions" section to the README covering handling, `UpdateMessage`, and deferred responses.

## Notes

Kept `UpdateMessage` as a standalone class (rather than refactoring `ReplyWithMessage` into a shared base) so this PR stays independent of the Tier 2 message-field PR and avoids cross-PR conflicts.