### PR TITLE
Add message field and component additions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,22 +15,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "${{ matrix.php-version }}"
+          extensions: gmp
 
       - name: Install dependencies
-        uses: php-actions/composer@v6
-        with:
-          php_version: "${{ matrix.php-version }}"
-          php_extensions: gmp
+        run: composer install --prefer-dist --no-progress
 
       - name: Run phpunit tests
-        uses: php-actions/phpunit@v3
-        with:
-          version: composer
-          bootstrap: vendor/autoload.php
-          php_version: "${{ matrix.php-version }}"
-          php_extensions: gmp
-          configuration: phpunit.xml
+        run: vendor/bin/phpunit --configuration phpunit.xml
 
   create-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
     runs-on: ubuntu-latest
 
     steps:
@@ -26,6 +26,7 @@ jobs:
       - name: Run phpunit tests
         uses: php-actions/phpunit@v3
         with:
+          version: composer
           bootstrap: vendor/autoload.php
           php_version: "${{ matrix.php-version }}"
           php_extensions: gmp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,19 +10,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "${{ matrix.php-version }}"
+          extensions: gmp
 
       - name: Install dependencies
-        uses: php-actions/composer@v6
-        with:
-          php_version: "${{ matrix.php-version }}"
-          php_extensions: gmp
+        run: composer install --prefer-dist --no-progress
 
       - name: Run phpunit tests
-        uses: php-actions/phpunit@v3
-        with:
-          version: composer
-          bootstrap: vendor/autoload.php
-          php_version: "${{ matrix.php-version }}"
-          php_extensions: gmp
-          configuration: phpunit.xml
+        run: vendor/bin/phpunit --configuration phpunit.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        php-version: [ 8.3 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
     runs-on: ubuntu-latest
 
     steps:
@@ -21,6 +21,7 @@ jobs:
       - name: Run phpunit tests
         uses: php-actions/phpunit@v3
         with:
+          version: composer
           bootstrap: vendor/autoload.php
           php_version: "${{ matrix.php-version }}"
           php_extensions: gmp

--- a/README.md
+++ b/README.md
@@ -75,6 +75,38 @@ $message->isRoleMentioned($roleId);
 $message->hasMentions();
 ```
 
+#### Controlling who gets pinged
+
+Mention syntax placed in a message's content notifies by default.  Use an `AllowedMentions` object to restrict (or fully suppress) those notifications:
+
+```php
+use \DiscordCommands\Messages\AllowedMentions;
+
+// suppress every mention - nobody gets pinged
+$message->setAllowedMentions(AllowedMentions::none());
+
+// or only allow specific roles/users to ping
+$allowed = new AllowedMentions();
+$allowed->allowRoles([$roleId]);
+$allowed->allowUsers([$userId]);
+$message->setAllowedMentions($allowed);
+```
+
+### Delivery options
+
+```php
+// send without triggering a push/desktop notification (a "silent" message)
+$message->sendSilently();
+
+// read the message aloud with text-to-speech
+$message->asTextToSpeech();
+
+// don't expand links/embeds in the message
+$message->withoutExpandingEmbeds();
+```
+
+These are available on `Message`, `WebhookMessage`, and `ReplyWithMessage`.
+
 ### Enriching
 
 Certain information can be enriched on the Discord side, such as linking to channels and timestamps in the user's local time.
@@ -179,6 +211,7 @@ $message->actionRow(new DangerButton('button-id', 'Reject it'));
 $message->actionRow(new PrimaryButton('button-id', 'Something else'));
 $message->actionRow(new SecondaryButton('button-id', 'Something else'));
 $message->actionRow(new LinkButton('https://mysite.com', 'My Site'));
+$message->actionRow(new PremiumButton('sku-id')); // links to a purchasable SKU
 ```
 
 ### SelectMenus
@@ -223,6 +256,19 @@ $message->addComponent(new ChannelSelectMenu($menuId, [
         Channel::TYPE_GUILD_VOICE,
     ],
 ]));
+```
+
+The auto-populated select menus (user, role, mentionable, and channel) can be pre-populated with default selections:
+
+```php
+$menu = new UserSelectMenu($menuId);
+$menu->addDefaultUser($userId);
+
+$menu = new RoleSelectMenu($menuId);
+$menu->addDefaultRole($roleId);
+
+$menu = new ChannelSelectMenu($menuId);
+$menu->addDefaultChannel($channelId);
 ```
 
 ### Text Input

--- a/src/Commands/Interactions/Responding/ReplyWithMessage.php
+++ b/src/Commands/Interactions/Responding/ReplyWithMessage.php
@@ -3,6 +3,7 @@
 namespace DiscordCommands\Commands\Interactions\Responding;
 
 use DiscordCommands\Jsonable;
+use DiscordCommands\Messages\AllowedMentions;
 use DiscordCommands\Messages\Components\Component;
 use DiscordCommands\Messages\Components\HasComponents;
 use DiscordCommands\Messages\Embed\Embed;
@@ -14,6 +15,7 @@ class ReplyWithMessage extends Jsonable implements CommandResponse
 
     public const FLAG_SUPPRESS_EMBEDS = 0x0000000000000004;
     public const FLAG_EPHEMERAL = 0x0000000000000040;
+    public const FLAG_SUPPRESS_NOTIFICATIONS = 0x0000000000001000;
 
     use HasComponents;
     use HasEmbeds;
@@ -21,6 +23,8 @@ class ReplyWithMessage extends Jsonable implements CommandResponse
     protected ?string $content;
     protected array $embeds = [];
     protected array $flags = [];
+    protected bool $tts = false;
+    protected ?AllowedMentions $allowedMentions = null;
 
     /**
      * @param string|null $content
@@ -103,6 +107,39 @@ class ReplyWithMessage extends Jsonable implements CommandResponse
         $this->flags[] = self::FLAG_EPHEMERAL;
     }
 
+    /**
+     * Send the reply without triggering a push/desktop notification.
+     */
+    public function sendSilently(): void
+    {
+        $this->flags[] = self::FLAG_SUPPRESS_NOTIFICATIONS;
+    }
+
+    public function asTextToSpeech(): void
+    {
+        $this->tts = true;
+    }
+
+    public function isTextToSpeech(): bool
+    {
+        return $this->tts;
+    }
+
+    public function setAllowedMentions(AllowedMentions $allowedMentions): void
+    {
+        $this->allowedMentions = $allowedMentions;
+    }
+
+    public function allowedMentions(): ?AllowedMentions
+    {
+        return $this->allowedMentions;
+    }
+
+    public function hasAllowedMentions(): bool
+    {
+        return $this->allowedMentions !== null;
+    }
+
     public function jsonSerialize(): array
     {
         $jsonData = [
@@ -111,6 +148,14 @@ class ReplyWithMessage extends Jsonable implements CommandResponse
 
         if (count($this->flags) > 0) {
             $jsonData['flags'] = array_sum($this->flags);
+        }
+
+        if ($this->isTextToSpeech()) {
+            $jsonData['tts'] = true;
+        }
+
+        if ($this->hasAllowedMentions()) {
+            $jsonData['allowed_mentions'] = $this->allowedMentions->jsonSerialize();
         }
 
         $traitsUsed = array_merge(class_uses(self::class), class_uses($this));

--- a/src/Messages/AllowedMentions.php
+++ b/src/Messages/AllowedMentions.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace DiscordCommands\Messages;
+
+use DiscordCommands\Jsonable;
+
+/**
+ * Controls which mentions in a message actually ping.  Without this, mention
+ * syntax placed in a message's content notifies by default.  Attach an instance
+ * to a message to restrict (or suppress) those notifications.
+ *
+ * @see https://discord.com/developers/docs/resources/message#allowed-mentions-object
+ */
+class AllowedMentions extends Jsonable
+{
+    protected ?array $parse = null;
+    protected array $roles = [];
+    protected array $users = [];
+    protected ?bool $repliedUser = null;
+
+    /**
+     * Suppress every mention in the message.
+     */
+    public static function none(): self
+    {
+        $allowedMentions = new self();
+        $allowedMentions->parse = [];
+
+        return $allowedMentions;
+    }
+
+    public function allowEveryone(): void
+    {
+        $this->addParse('everyone');
+    }
+
+    public function allowAllRoles(): void
+    {
+        $this->addParse('roles');
+    }
+
+    public function allowAllUsers(): void
+    {
+        $this->addParse('users');
+    }
+
+    /**
+     * Allow only the given role ids to ping.
+     *
+     * @param string[] $roleIds
+     */
+    public function allowRoles(array $roleIds): void
+    {
+        $this->roles = array_merge($this->roles, $roleIds);
+    }
+
+    /**
+     * Allow only the given user ids to ping.
+     *
+     * @param string[] $userIds
+     */
+    public function allowUsers(array $userIds): void
+    {
+        $this->users = array_merge($this->users, $userIds);
+    }
+
+    public function mentionRepliedUser(bool $mention = true): void
+    {
+        $this->repliedUser = $mention;
+    }
+
+    private function addParse(string $type): void
+    {
+        if ($this->parse === null) {
+            $this->parse = [];
+        }
+
+        if (!in_array($type, $this->parse, true)) {
+            $this->parse[] = $type;
+        }
+    }
+
+    public function jsonSerialize(): array
+    {
+        $data = [];
+
+        if ($this->parse !== null) {
+            $data['parse'] = $this->parse;
+        }
+
+        if (count($this->roles) > 0) {
+            $data['roles'] = array_values($this->roles);
+        }
+
+        if (count($this->users) > 0) {
+            $data['users'] = array_values($this->users);
+        }
+
+        if ($this->repliedUser !== null) {
+            $data['replied_user'] = $this->repliedUser;
+        }
+
+        return $data;
+    }
+}

--- a/src/Messages/Components/Types/Button.php
+++ b/src/Messages/Components/Types/Button.php
@@ -12,6 +12,7 @@ abstract class Button extends Component
     protected ?string $label = null;
     protected ?string $id = null;
     protected ?string $url = null;
+    protected ?string $skuId = null;
     protected ?PartialEmoji $emoji = null;
     protected bool $disabled = false;
 
@@ -22,6 +23,7 @@ abstract class Button extends Component
         ?string $url = null,
         ?PartialEmoji $emoji = null,
         bool $disabled = false,
+        ?string $skuId = null,
     ) {
         parent::__construct(self::TYPE);
 
@@ -30,6 +32,7 @@ abstract class Button extends Component
         $this->url = $url;
         $this->emoji = $emoji;
         $this->disabled = $disabled;
+        $this->skuId = $skuId;
     }
 
     public function style(): int
@@ -87,6 +90,21 @@ abstract class Button extends Component
         return $this->url !== null;
     }
 
+    public function skuId(): string
+    {
+        return $this->skuId;
+    }
+
+    public function setSkuId(string $skuId): void
+    {
+        $this->skuId = $skuId;
+    }
+
+    public function hasSkuId(): bool
+    {
+        return $this->skuId !== null;
+    }
+
     public function isEnabled(): bool
     {
         return $this->disabled === false;
@@ -118,6 +136,10 @@ abstract class Button extends Component
 
         if ($this->hasId()) {
             $data['custom_id'] = $this->id();
+        }
+
+        if ($this->hasSkuId()) {
+            $data['sku_id'] = $this->skuId();
         }
 
         if ($this->emoji instanceof PartialEmoji) {

--- a/src/Messages/Components/Types/Buttons/PremiumButton.php
+++ b/src/Messages/Components/Types/Buttons/PremiumButton.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace DiscordCommands\Messages\Components\Types\Buttons;
+
+use DiscordCommands\Messages\Components\Types\Button;
+
+/**
+ * A premium button links to a purchasable SKU.  Unlike other buttons it has no
+ * label, custom_id, or emoji - Discord renders it using the SKU's details.
+ */
+class PremiumButton extends Button
+{
+    public const STYLE = 6;
+
+    public function __construct(
+        string $skuId,
+        bool $disabled = false,
+    ) {
+        parent::__construct(
+            style: self::STYLE,
+            disabled: $disabled,
+            skuId: $skuId,
+        );
+    }
+}

--- a/src/Messages/Components/Types/SelectMenu.php
+++ b/src/Messages/Components/Types/SelectMenu.php
@@ -9,6 +9,7 @@ abstract class SelectMenu extends Component
     protected ?string $placeholder;
     protected ?int $minValues;
     protected ?int $maxValues;
+    protected array $defaultValues = [];
 
     public function __construct(
         protected int $type,
@@ -62,6 +63,46 @@ abstract class SelectMenu extends Component
         $this->maxValues = $maxValues;
     }
 
+    /**
+     * Pre-selected values for auto-populated select menus (user, role,
+     * mentionable, and channel menus).  Each entry is an array of
+     * ['id' => ..., 'type' => 'user'|'role'|'channel'].
+     *
+     * @return array[]
+     */
+    public function defaultValues(): array
+    {
+        return $this->defaultValues;
+    }
+
+    public function hasDefaultValues(): bool
+    {
+        return count($this->defaultValues) > 0;
+    }
+
+    public function addDefaultValue(string $id, string $type): void
+    {
+        $this->defaultValues[] = [
+            'id' => $id,
+            'type' => $type,
+        ];
+    }
+
+    public function addDefaultUser(string $userId): void
+    {
+        $this->addDefaultValue($userId, 'user');
+    }
+
+    public function addDefaultRole(string $roleId): void
+    {
+        $this->addDefaultValue($roleId, 'role');
+    }
+
+    public function addDefaultChannel(string $channelId): void
+    {
+        $this->addDefaultValue($channelId, 'channel');
+    }
+
     public function isEnabled(): bool
     {
         return $this->disabled === false;
@@ -85,6 +126,10 @@ abstract class SelectMenu extends Component
             'min_values' => $this->minValues(),
             'max_values' => $this->maxValues(),
         ];
+
+        if ($this->hasDefaultValues()) {
+            $data['default_values'] = $this->defaultValues();
+        }
 
         $data = array_filter(
             array_merge(

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -19,7 +19,13 @@ class Message extends Jsonable implements Hydrateable
     use HasEmbeds;
     use MentionsRoles;
 
+    public const FLAG_SUPPRESS_EMBEDS = 0x0000000000000004;
+    public const FLAG_SUPPRESS_NOTIFICATIONS = 0x0000000000001000;
+
     protected ?string $content;
+    protected array $flags = [];
+    protected bool $tts = false;
+    protected ?AllowedMentions $allowedMentions = null;
 
     /**
      * @param string|null $content
@@ -34,6 +40,44 @@ class Message extends Jsonable implements Hydrateable
         $this->content = $content;
         $this->embeds = $embeds;
         $this->components = $components;
+    }
+
+    /**
+     * Send the message without triggering a push/desktop notification.
+     */
+    public function sendSilently(): void
+    {
+        $this->flags[] = self::FLAG_SUPPRESS_NOTIFICATIONS;
+    }
+
+    public function withoutExpandingEmbeds(): void
+    {
+        $this->flags[] = self::FLAG_SUPPRESS_EMBEDS;
+    }
+
+    public function asTextToSpeech(): void
+    {
+        $this->tts = true;
+    }
+
+    public function isTextToSpeech(): bool
+    {
+        return $this->tts;
+    }
+
+    public function setAllowedMentions(AllowedMentions $allowedMentions): void
+    {
+        $this->allowedMentions = $allowedMentions;
+    }
+
+    public function allowedMentions(): ?AllowedMentions
+    {
+        return $this->allowedMentions;
+    }
+
+    public function hasAllowedMentions(): bool
+    {
+        return $this->allowedMentions !== null;
     }
 
     /**
@@ -79,6 +123,18 @@ class Message extends Jsonable implements Hydrateable
         $jsonData = [
             'content' => $this->content(),
         ];
+
+        if (count($this->flags) > 0) {
+            $jsonData['flags'] = array_sum($this->flags);
+        }
+
+        if ($this->isTextToSpeech()) {
+            $jsonData['tts'] = true;
+        }
+
+        if ($this->hasAllowedMentions()) {
+            $jsonData['allowed_mentions'] = $this->allowedMentions->jsonSerialize();
+        }
 
         $traitsUsed = array_merge(class_uses(self::class), class_uses($this));
         if (in_array(HasComponents::class, $traitsUsed)) {

--- a/src/Messages/WebhookMessage.php
+++ b/src/Messages/WebhookMessage.php
@@ -14,10 +14,16 @@ class WebhookMessage extends Jsonable implements Hydrateable
     use HasEmbeds;
     use MentionsRoles;
 
+    public const FLAG_SUPPRESS_EMBEDS = 0x0000000000000004;
+    public const FLAG_SUPPRESS_NOTIFICATIONS = 0x0000000000001000;
+
     protected ?string $content;
     protected ?string $threadName;
     protected ?string $webhookUsername;
     protected ?string $webhookAvatarUrl;
+    protected array $flags = [];
+    protected bool $tts = false;
+    protected ?AllowedMentions $allowedMentions = null;
 
     /**
      * @param string|null $content
@@ -65,6 +71,44 @@ class WebhookMessage extends Jsonable implements Hydrateable
         return $this->threadName;
     }
 
+    /**
+     * Send the message without triggering a push/desktop notification.
+     */
+    public function sendSilently(): void
+    {
+        $this->flags[] = self::FLAG_SUPPRESS_NOTIFICATIONS;
+    }
+
+    public function withoutExpandingEmbeds(): void
+    {
+        $this->flags[] = self::FLAG_SUPPRESS_EMBEDS;
+    }
+
+    public function asTextToSpeech(): void
+    {
+        $this->tts = true;
+    }
+
+    public function isTextToSpeech(): bool
+    {
+        return $this->tts;
+    }
+
+    public function setAllowedMentions(AllowedMentions $allowedMentions): void
+    {
+        $this->allowedMentions = $allowedMentions;
+    }
+
+    public function allowedMentions(): ?AllowedMentions
+    {
+        return $this->allowedMentions;
+    }
+
+    public function hasAllowedMentions(): bool
+    {
+        return $this->allowedMentions !== null;
+    }
+
     public function hydrate(array $array): self
     {
         if (isset($array['content'])) {
@@ -97,6 +141,18 @@ class WebhookMessage extends Jsonable implements Hydrateable
 
         if (isset($this->threadName)) {
             $jsonData['thread_name'] = $this->threadName;
+        }
+
+        if (count($this->flags) > 0) {
+            $jsonData['flags'] = array_sum($this->flags);
+        }
+
+        if ($this->isTextToSpeech()) {
+            $jsonData['tts'] = true;
+        }
+
+        if ($this->hasAllowedMentions()) {
+            $jsonData['allowed_mentions'] = $this->allowedMentions->jsonSerialize();
         }
 
         $traitsUsed = array_merge(class_uses(self::class), class_uses($this));

--- a/tests/Commands/Interactions/Responding/ReplyWithMessageTest.php
+++ b/tests/Commands/Interactions/Responding/ReplyWithMessageTest.php
@@ -3,6 +3,7 @@
 namespace DiscordCommands\Commands\Interactions\Responding\Responses;
 
 use DiscordCommands\Commands\Interactions\Responding\ReplyWithMessage;
+use DiscordCommands\Messages\AllowedMentions;
 use DiscordCommands\Messages\Components\Types\Buttons\PrimaryButton;
 use DiscordCommands\Messages\Embed\Embed;
 use PHPUnit\Framework\Attributes\Test;
@@ -67,6 +68,49 @@ class ReplyWithMessageTest extends TestCase
         if (!(ReplyWithMessage::FLAG_EPHEMERAL & $json['data']['flags'])) {
             $this->assertTrue(false, 'ephemeral bitwise operator not applied');
         }
+    }
+
+    #[Test]
+    public function canBeSentSilently()
+    {
+        $response = new ReplyWithMessage();
+        $response->sendSilently();
+
+        $json = $response->jsonSerialize();
+
+        $this->assertArrayHasKey('flags', $json['data']);
+        if (!(ReplyWithMessage::FLAG_SUPPRESS_NOTIFICATIONS & $json['data']['flags'])) {
+            $this->assertTrue(false, 'suppress notifications bitwise operator not applied');
+        }
+    }
+
+    #[Test]
+    public function canBeTextToSpeech()
+    {
+        $response = new ReplyWithMessage();
+
+        $this->assertFalse($response->isTextToSpeech());
+        $this->assertArrayNotHasKey('tts', $response->jsonSerialize()['data']);
+
+        $response->asTextToSpeech();
+
+        $this->assertTrue($response->jsonSerialize()['data']['tts']);
+    }
+
+    #[Test]
+    public function canRestrictAllowedMentions()
+    {
+        $response = new ReplyWithMessage();
+
+        $this->assertFalse($response->hasAllowedMentions());
+
+        $response->setAllowedMentions(AllowedMentions::none());
+
+        $this->assertTrue($response->hasAllowedMentions());
+
+        $json = $response->jsonSerialize();
+        $this->assertArrayHasKey('allowed_mentions', $json['data']);
+        $this->assertEquals(['parse' => []], $json['data']['allowed_mentions']);
     }
 
     #[Test]

--- a/tests/Messages/AllowedMentionsTest.php
+++ b/tests/Messages/AllowedMentionsTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace DiscordCommands\Messages;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class AllowedMentionsTest extends TestCase
+{
+    #[Test]
+    public function isEmptyByDefault()
+    {
+        $this->assertEquals([], (new AllowedMentions())->jsonSerialize());
+    }
+
+    #[Test]
+    public function noneSuppressesEverything()
+    {
+        $this->assertEquals(
+            ['parse' => []],
+            AllowedMentions::none()->jsonSerialize()
+        );
+    }
+
+    #[Test]
+    public function canAllowMentionTypes()
+    {
+        $allowedMentions = new AllowedMentions();
+        $allowedMentions->allowEveryone();
+        $allowedMentions->allowAllRoles();
+        $allowedMentions->allowAllUsers();
+
+        // adding a duplicate does not repeat it
+        $allowedMentions->allowEveryone();
+
+        $this->assertEquals(
+            ['parse' => ['everyone', 'roles', 'users']],
+            $allowedMentions->jsonSerialize()
+        );
+    }
+
+    #[Test]
+    public function canAllowSpecificRolesAndUsers()
+    {
+        $allowedMentions = new AllowedMentions();
+        $allowedMentions->allowRoles(['1', '2']);
+        $allowedMentions->allowUsers(['3']);
+        $allowedMentions->mentionRepliedUser();
+
+        $this->assertEquals(
+            [
+                'roles' => ['1', '2'],
+                'users' => ['3'],
+                'replied_user' => true,
+            ],
+            $allowedMentions->jsonSerialize()
+        );
+    }
+}

--- a/tests/Messages/Components/Types/Buttons/PremiumButtonTest.php
+++ b/tests/Messages/Components/Types/Buttons/PremiumButtonTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace DiscordCommands\Messages\Components\Types\Buttons;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class PremiumButtonTest extends TestCase
+{
+    #[Test]
+    public function canBeConstructedAndJsonified()
+    {
+        $skuId = '1234567890';
+        $button = new PremiumButton($skuId);
+
+        $this->assertEquals($skuId, $button->skuId());
+
+        $json = $button->jsonSerialize();
+
+        $this->assertEquals(PremiumButton::STYLE, $json['style']);
+        $this->assertEquals(6, $json['style']);
+        $this->assertArrayHasKey('sku_id', $json);
+        $this->assertEquals($skuId, $json['sku_id']);
+
+        // premium buttons carry no label or custom_id
+        $this->assertArrayNotHasKey('label', $json);
+        $this->assertArrayNotHasKey('custom_id', $json);
+    }
+}

--- a/tests/Messages/Components/Types/SelectMenuTest.php
+++ b/tests/Messages/Components/Types/SelectMenuTest.php
@@ -22,4 +22,29 @@ class SelectMenuTest extends TestCase
         $this->assertArrayHasKey('custom_id', $json);
         $this->assertEquals($selectMenu->id(), $json['custom_id']);
     }
+
+    #[Test]
+    public function canProvideDefaultValues()
+    {
+        $selectMenu = new class(5, 'asdf') extends SelectMenu {
+        };
+
+        $this->assertFalse($selectMenu->hasDefaultValues());
+        $this->assertArrayNotHasKey('default_values', $selectMenu->jsonSerialize());
+
+        $selectMenu->addDefaultUser('111');
+        $selectMenu->addDefaultRole('222');
+        $selectMenu->addDefaultChannel('333');
+
+        $this->assertTrue($selectMenu->hasDefaultValues());
+
+        $json = $selectMenu->jsonSerialize();
+
+        $this->assertArrayHasKey('default_values', $json);
+        $this->assertEquals([
+            ['id' => '111', 'type' => 'user'],
+            ['id' => '222', 'type' => 'role'],
+            ['id' => '333', 'type' => 'channel'],
+        ], $json['default_values']);
+    }
 }

--- a/tests/Messages/MessageTest.php
+++ b/tests/Messages/MessageTest.php
@@ -172,4 +172,63 @@ class MessageTest extends TestCase
             Message::timestamp($timestamp, TimestampFormat::RELATIVE)
         );
     }
+
+    #[Test]
+    public function hasNoFlagsByDefault()
+    {
+        $this->assertArrayNotHasKey('flags', $this->message->jsonSerialize());
+    }
+
+    #[Test]
+    public function canBeSentSilently()
+    {
+        $this->message->sendSilently();
+
+        $json = $this->message->jsonSerialize();
+
+        $this->assertArrayHasKey('flags', $json);
+        if (!(Message::FLAG_SUPPRESS_NOTIFICATIONS & $json['flags'])) {
+            $this->assertTrue(false, 'suppress notifications bitwise operator not applied');
+        }
+    }
+
+    #[Test]
+    public function canSuppressEmbeds()
+    {
+        $this->message->withoutExpandingEmbeds();
+
+        $json = $this->message->jsonSerialize();
+
+        $this->assertArrayHasKey('flags', $json);
+        if (!(Message::FLAG_SUPPRESS_EMBEDS & $json['flags'])) {
+            $this->assertTrue(false, 'suppress embeds bitwise operator not applied');
+        }
+    }
+
+    #[Test]
+    public function canBeTextToSpeech()
+    {
+        $this->assertFalse($this->message->isTextToSpeech());
+        $this->assertArrayNotHasKey('tts', $this->message->jsonSerialize());
+
+        $this->message->asTextToSpeech();
+
+        $this->assertTrue($this->message->isTextToSpeech());
+        $this->assertTrue($this->message->jsonSerialize()['tts']);
+    }
+
+    #[Test]
+    public function canRestrictAllowedMentions()
+    {
+        $this->assertFalse($this->message->hasAllowedMentions());
+        $this->assertArrayNotHasKey('allowed_mentions', $this->message->jsonSerialize());
+
+        $this->message->setAllowedMentions(AllowedMentions::none());
+
+        $this->assertTrue($this->message->hasAllowedMentions());
+
+        $json = $this->message->jsonSerialize();
+        $this->assertArrayHasKey('allowed_mentions', $json);
+        $this->assertEquals(['parse' => []], $json['allowed_mentions']);
+    }
 }

--- a/tests/Messages/WebhookMessageTest.php
+++ b/tests/Messages/WebhookMessageTest.php
@@ -162,4 +162,45 @@ class WebhookMessageTest extends TestCase
         $this->assertArrayHasKey('components', $json);
         $this->assertEquals($compId, $json['components'][0]['custom_id']);
     }
+
+    #[Test]
+    public function canBeSentSilently()
+    {
+        $this->assertArrayNotHasKey('flags', $this->message->jsonSerialize());
+
+        $this->message->sendSilently();
+
+        $json = $this->message->jsonSerialize();
+        $this->assertArrayHasKey('flags', $json);
+        if (!(WebhookMessage::FLAG_SUPPRESS_NOTIFICATIONS & $json['flags'])) {
+            $this->assertTrue(false, 'suppress notifications bitwise operator not applied');
+        }
+    }
+
+    #[Test]
+    public function canBeTextToSpeech()
+    {
+        $this->assertFalse($this->message->isTextToSpeech());
+        $this->assertArrayNotHasKey('tts', $this->message->jsonSerialize());
+
+        $this->message->asTextToSpeech();
+
+        $this->assertTrue($this->message->jsonSerialize()['tts']);
+    }
+
+    #[Test]
+    public function canRestrictAllowedMentions()
+    {
+        $this->assertFalse($this->message->hasAllowedMentions());
+
+        $allowedMentions = new AllowedMentions();
+        $allowedMentions->allowRoles(['12345']);
+        $this->message->setAllowedMentions($allowedMentions);
+
+        $this->assertTrue($this->message->hasAllowedMentions());
+
+        $json = $this->message->jsonSerialize();
+        $this->assertArrayHasKey('allowed_mentions', $json);
+        $this->assertEquals(['roles' => ['12345']], $json['allowed_mentions']);
+    }
 }


### PR DESCRIPTION
## What

Expands outbound serialization coverage with several small, isolated additions, each matching an existing pattern in the library.

## Changes

- **`AllowedMentions`** — controls which mentions in a message actually ping (mention syntax in content notifies by default). `AllowedMentions::none()` suppresses everything; `allowRoles()/allowUsers()/allowEveryone()` etc. for finer control. Wired into `Message`, `WebhookMessage`, and `ReplyWithMessage` via `setAllowedMentions()`.
- **Message flags + TTS** — `Message`/`WebhookMessage` had no flag support at all. Adds `sendSilently()` (SUPPRESS_NOTIFICATIONS), `withoutExpandingEmbeds()` (SUPPRESS_EMBEDS), and `asTextToSpeech()`. `ReplyWithMessage` gains the silent flag and `asTextToSpeech()` for parity.
- **`PremiumButton`** — button style 6, backed by a `sku_id` (links to a purchasable SKU). Small extension to the `Button` base to carry/serialize `sku_id`.
- **Select menu `default_values`** — pre-select entries on the auto-populated menus (user/role/mentionable/channel) via `addDefaultUser()/addDefaultRole()/addDefaultChannel()` on the `SelectMenu` base.

## Tests

17 new tests (125 total, all green). Covers each new field's serialization plus the `AllowedMentions` variants.

## Docs

README updated: a "Controlling who gets pinged" section, a "Delivery options" section (silent / TTS / suppress embeds), the `PremiumButton` example, and select-menu default values.

## Notes

Independent of the component-interactions PR (#20) — no overlapping files.